### PR TITLE
Add X-Clacks Overhead memorials http head/meta tags

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -6,6 +6,10 @@
   <title>{% if page.title %}{{ page.title }} &ndash; {% endif %}{{ site.title }}</title>
 
   <meta name="description" content="PyCon UK {{ site.con_start }} to {{ site.con_finish }} {{ site.con_year }}, {{ site.con_location }}">
+  
+  <meta http-equiv="X-Clacks-Overhead" content="GNU John Pinner" /> 
+  <meta http-equiv="X-Clacks-Overhead" content="GNU Russel Winder" /> 
+
 
   <link rel="canonical" href="{{ page.url | replace:'index.html', '' | absolute_url }}">
   <link type="application/atom+xml" rel="alternate" href="{{ site.url }}/atom.xml">


### PR DESCRIPTION
i thought this might be a nice quiet memorial.

this html `<meta>` tag is the [recommended way](http://www.gnuterrypratchett.com/#HTML) to implement gnu-terry-pratchett if you don't have control over your webserver's headers.

looks like we're currently hosted by netlify so [there may be another way](https://docs.netlify.com/routing/headers/) -- but that would lock us into netlify a bit?  this felt more vendor-neutral.  not that bothered tho.  more keen on making the gesture one way or another.

already approved here https://github.com/PyconUK/2022.pyconuk.org/pull/37/files