### PR TITLE
Remove guess-the-month minigame

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,9 +18,8 @@ title: "PyCon UK 2023"
 
 # When changing the year, please change it in the title, above. We can't use vars in vars.
 con_year: 2023
-con_month: September
-con_start: Friday 22nd
-con_finish: Monday 25th
+con_start: Friday 22nd September
+con_finish: Monday 25th September
 con_financial_assistance_deadline: "XX:00 (Europe/London) on Someday, Nth Somemonth"
 
 # Ticket prices should include VAT at 20%.

--- a/src/index.md
+++ b/src/index.md
@@ -5,4 +5,4 @@ layout: default
 ## PyCon UK will be returning to {{ site.con_location }} from {{ site.con_start }} to {{ site.con_finish }} {{ site.con_year }}.
 
 <p>Do you have an idea for a talk, workshop, or similar? <a href="/call-for-proposals/">Tell us about it!</a></p>
-<p><a href="/tickets">Join us in {{ site.con_month }}!</a></p>
+<p><a href="/tickets">Join us in {{ site.con_location }}!</a></p>


### PR DESCRIPTION
While it's reasonably solvable this year, it wasn't intentional and is probably not very helpful generally speaking to make potential attendees try to guess the month of the conference.