### PR TITLE
Ensure items use a new row when display is narrow

### DIFF
--- a/src/_sass/columns.scss
+++ b/src/_sass/columns.scss
@@ -6,6 +6,7 @@
 
   @media screen and (max-width: 500px) {
     grid-template-columns: 100%;
+    grid-auto-flow: row;
   }
 
   .box {


### PR DESCRIPTION
This should fix the layout issues for the attendee portal on mobile