### PR TITLE
Give schedule more room, CSS transform to fit more screens

### DIFF
--- a/src/_layouts/schedule.html
+++ b/src/_layouts/schedule.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  {% include head.html %}
+
+  <body>
+    {% include header.html %}
+
+    <main>
+      <div id="main_inner">
+        {% if page.title %}
+        <h2>{{ page.title }}</h2>
+        {% endif %}
+
+        {{ content }}
+      </div>
+    </main>
+
+    {% include footer.html %}
+  </body>
+</html>

--- a/src/_layouts/schedule.html
+++ b/src/_layouts/schedule.html
@@ -14,8 +14,56 @@
 
         {{ content }}
       </div>
-    </main>
 
+{% if site.schedule_ready == true %}
+<pretalx-schedule
+  id='pretalx-schedule'
+  event-url="https://pretalx.com/pyconuk-{{ site.con_year }}/" locale="en"
+  style="--pretalx-clr-primary: #3aa57c; display: block; margin: 0 auto;">
+</pretalx-schedule>
+
+<script language='javascript'>
+  /* This is a hack to resize the injected pretalx schedule so more of
+   * it fits on the page, without knowing anything about the inner
+   * structure of the injected content.
+   *
+   * We wait for the page to have horizontal scroll-bar, at which point
+   * we can calculate ratios for CSS transforms that shrink the width
+   * of the injected content so it fits horizontally again. A shrinking
+   * CSS transform will center the content by default, so first we use a
+   * translation to shift it to the left (the order of transform operations
+   * matters).
+   *
+   * To keep things from getting too squished, we never scale down to
+   * less than 70% of the original content width.
+   *
+   * Sadly, if the user resizes their browser window or zooms in/out,
+   * they will need to refresh to get this to run again.
+   */
+  var rescale_done = false;
+  function rescale_schedue() {
+    if (!rescale_done) {
+      var ratio1 = Math.max(70, Math.round(100 * window.innerWidth / document.documentElement.scrollWidth) - 2);
+      var ratio2 = Math.round((100 - ratio1)/2);
+      if (ratio1 < 100) {
+        var ps = document.getElementById('pretalx-schedule');
+        var style = ps.getAttribute('style');
+        ps.setAttribute('style', style + 'transform: translateX(-' + ratio2 +'%) scaleX('+ ratio1 +'%);');
+        rescale_done = true;
+      }
+    }
+  }
+  /* Check whether we need to resize every 50ms, starting 500ms after
+   * this compiles and giving up after 4 seconds.
+   */
+  for (var i = 10; i < 80; i++) {
+    setTimeout(rescale_schedue, 50 * i);
+  }
+  </script>
+
+{% endif %}
+
+    </main>
     {% include footer.html %}
   </body>
 </html>

--- a/src/schedule.md
+++ b/src/schedule.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: schedule
 title: Schedule
 ---
 
@@ -8,10 +8,9 @@ title: Schedule
 
 {% if site.schedule_ready == true %}
 <p>All ticket holders are entitled to join the sprints day at no additional charge.</p>
-<p>If you can't see the schedule widget, you can <a href="https://pretalx.com/pyconuk-{{ site.con_year }}/schedule/">view the schedule here.</a></p>
+<p>If you can't see the schedule widget, you can <a href="https://pretalx.com/pyconuk-{{ site.con_year }}/schedule/">view the schedule here.</a> On some screens you may need to scroll left or right to see all the tracks.</p>
 
 <script type="text/javascript" src="https://pretalx.com/pyconuk-{{ site.con_year }}/schedule/widget/v2.en.js"></script>
-<pretalx-schedule event-url="https://pretalx.com/pyconuk-{{ site.con_year }}/" locale="en" style="--pretalx-clr-primary: #3aa57c"></pretalx-schedule>
 {% else %}
 <p>The conference will be made up of 3 days of talks and workshops from Friday - Sunday and a single day of sprints on Monday. All ticket holders are entitled to join the sprints day at no additional charge.</p>
 


### PR DESCRIPTION
Hi!

This PR creates a new layout for the schedule, which does two things:

1. It takes the pretalx injected content out of the `main_inner` div, so it doesn't have the same margin on the left.
2. Adds a Javascript hack which uses CSS transforms to shrink the injected content so it can be seen without scrolling on more screens.

I am not sure whether the Javascript is an awesome or ugly hack - maybe a bit of both?

The main benefit of this approach, is it's completely immune to changes made on the pretalx side: it just detects that the pretalx element resized our page so much that we now need a horizontal scrollbar, and tries to scale it back down again to undo that (within reasonable limits). If no scrollbar was necessary, then nothing is done.

Known bugs: If pretalx content takes more than 4 seconds to load, we will have given up and won't resize. If the user resizes their browser after the fact, or zooms in/out, they will need to reload to get the resizing algorithm to do its thing.